### PR TITLE
Improvements to library configuration.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,6 @@ end
 Rake::RDocTask.new(rdoc: "doc", clobber_rdoc: "doc:clean", rerdoc: "doc:force") do |rdoc|
   rdoc.main = "README.md"
   rdoc.title = "Orchestrate API Documentation"
-  rdoc.options << "--all"
   rdoc.options << "--line-numbers"
   rdoc.rdoc_files.include("README.md", "lib/**/*.rb")
   rdoc.rdoc_dir = "doc"

--- a/lib/orchestrate-api.rb
+++ b/lib/orchestrate-api.rb
@@ -1,14 +1,50 @@
+#
+# A library for supporting connections to the \Orchestrate API.
+#
 module Orchestrate
 
-=begin rdoc
-  ==== orchestrate-api
+  # Configuration ------------------------------------------------------------
 
-  Ruby gem <tt>orchestrate-api</tt> provides an
-  interface to the <b>Orchestrate.io</b> *API*.
+  require "orchestrate/configuration"
 
-  The <b>Wrapper[API/Wrapper.html]</b> class is used to setup the client and make HTTP requests.
-=end
+  class << self
 
+    #
+    # An instance of Configuration containing the current library
+    # configuration options.
+    #
+    attr_accessor :config
+
+    #
+    # Lazily initialize and return the Configuration instance.
+    #
+    def config # :nodoc:
+      @config ||= Configuration.new
+    end
+
+    #
+    # Configure the Orchestrate library. This method should be called during
+    # application or script initialization. At a bare minimum, the Orchestrate
+    # library will require that an API key is provided.
+    #
+    # ==== Example
+    #
+    #   Orchestrate.configure do |config|
+    #     config.api_key = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    #   end
+    #
+    def configure
+      yield config
+    end
+
+  end
+
+  #
+  # Ruby gem +orchestrate-api+ provides an interface to the
+  # [Orchestrate](http://orchestrate.io) API.
+  #
+  # The API::Wrapper class is used to setup the client and make HTTP requests.
+  #
   module API
 
     require "orchestrate/api/procedural"
@@ -20,4 +56,5 @@ module Orchestrate
     require "orchestrate/api/extensions"
 
   end
+
 end

--- a/lib/orchestrate/api/request.rb
+++ b/lib/orchestrate/api/request.rb
@@ -2,7 +2,7 @@ module Orchestrate::API
 
   require 'net/http'
 
-  class Request < Object
+  class Request
 
     # The HTTP method - must be one of: [ :get, :put, :delete ].
     attr_accessor :method

--- a/lib/orchestrate/api/wrapper.rb
+++ b/lib/orchestrate/api/wrapper.rb
@@ -1,57 +1,64 @@
 module Orchestrate::API
 
-  require 'json'
-
-  # ==== Ruby wrapper for the Orchestrate.io REST *API*.
+  # ==== Ruby wrapper for the Orchestrate REST *API*.
   #
-  # The primary entry point is the <b> #send_request</b> method, which
-  # generates a <b> Request</b>, and returns the
-  # <b> Response</b> to the caller.
-  # <b>{Usage examples for each HTTP request}[Procedural.html]</b>
-  # are documented in the <b> Procedural</b> interface module.
+  # The primary entry point is the #send_request method, which generates a
+  # Request, and returns the Response to the caller.
+  #
+  # {Usage examples for each HTTP request}[Procedural.html] are documented in
+  # the Procedural interface module.
   #
   class Wrapper
+
     include Orchestrate::API::Procedural
 
-    attr_accessor :verbose
+    #
+    # Configuration for the wrapper instance. If configuration is not
+    # explicitly provided during initialization, this will default to
+    # Orchestrate.config.
+    #
+    attr_accessor :config
 
-    # Loads settings from the configuration file and returns the client
-    # handle to be used for subsequent requests.
     #
-    #  Example config file: "./lib/orch_config.json"
+    # Returns the wrapper configuration. If the wrapper does not have
+    # explicitly provided configuration, this will return the global
+    # configuration from Orchestrate.config.
     #
-    #   {
-    #     "base_url":"https://api.orchestrate.io/v0",
-    #     "user":"<user-key-from-orchestrate.io>",
-    #     "verbose":"false"
-    #   }
-    #
-    def initialize(config_file)
-      orch_config = JSON.parse open(config_file).read
-      @base_url = orch_config['base_url']
-      @user     = orch_config['user']
-      @verbose  = orch_config['verbose'] && orch_config['verbose'] == 'true' ? true
-                                                                             : false
+    def config # :nodoc:
+      @config ||= Orchestrate.config
     end
 
+    #
+    # Initialize and return a new Wrapper instance. Optionally, configure
+    # options for the instance by passing a Configuration object. If no
+    # custom configuration is provided, the configuration options from
+    # Orchestrate.config will be used.
+    def initialize(config = nil)
+      @config = config
+    end
+
+    #
     # Creates the Request object and sends it via the perform method,
     # which generates and returns the Response object.
     #
     def send_request(method, args)
-      request = Orchestrate::API::Request.new(method, build_url(method, args), @user) do |r|
+      request = Orchestrate::API::Request.new(method, build_url(method, args), config.api_key) do |r|
         r.data = args[:json] if args[:json]
         r.ref = args[:ref] if args[:ref]
-        r.verbose = verbose
+        r.verbose = config.verbose
       end
       request.perform
     end
 
+    # ------------------------------------------------------------------------
+
     private
 
+      #
       # Builds the URL for each HTTP request to the orchestrate.io api.
       #
       def build_url(method, args)
-        Orchestrate::API::URL.new(method, @base_url, args).path
+        Orchestrate::API::URL.new(method, config.base_url, args).path
       end
 
   end

--- a/lib/orchestrate/api/wrapper.rb
+++ b/lib/orchestrate/api/wrapper.rb
@@ -10,7 +10,7 @@ module Orchestrate::API
   # <b>{Usage examples for each HTTP request}[Procedural.html]</b>
   # are documented in the <b> Procedural</b> interface module.
   #
-  class Wrapper < Object
+  class Wrapper
     include Orchestrate::API::Procedural
 
     attr_accessor :verbose

--- a/lib/orchestrate/configuration.rb
+++ b/lib/orchestrate/configuration.rb
@@ -1,0 +1,49 @@
+module Orchestrate
+
+  #
+  # Represents the configuration for the Orchestrate library, including
+  # values for the api key, base url and other settings.
+  #
+  # An instance of this class is always available at Orchestrate.config.
+  # You should not
+  # instantiate instances of this class, instead, you should configure the
+  # library with the Orchestrate.configure method.
+  #
+  # === Example
+  #
+  #     Orchestrate.configure do |config|
+  #       config.api_key = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  #       config.verbose = true
+  #     end
+  #
+  class Configuration
+
+    #
+    # The api key for your app, from the Orchestrate Dashboard.
+    #
+    attr_accessor :api_key
+
+    #
+    # The url to the Orchestrate API. Defaults to \https://api.orchestrate.io/v0.
+    #
+    attr_accessor :base_url
+
+    #
+    # Controlers whether verbose output is enabled. Default +false+.
+    #
+    # TODO Replace this with logger with log levels
+    #
+    attr_accessor :verbose
+
+    #
+    # Initialize and return a new instance of Configuration.
+    #
+    def initialize(options = {}) # :nodoc:
+      @api_key = options[:api_key]
+      @base_url = options[:base_url] || "https://api.orchestrate.io/v0"
+      @verbose = options[:verbose].nil? ? false : options[:verbose]
+    end
+
+  end
+
+end

--- a/test/lib/orch_config-demo.json
+++ b/test/lib/orch_config-demo.json
@@ -1,5 +1,0 @@
-{
-	"base_url":"https://api.orchestrate.io/v0",
-  "user":"0384407c-95e1-4b27-aa6f-c5a7cb685015",
-  "verbose":"true"
-}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,19 @@
 require "minitest/autorun"
+require "json"
 require "vcr"
 
 require "orchestrate-api"
 
 # Configure Orchestrate API Client -------------------------------------------
 
+Orchestrate.configure do |config|
+  config.api_key = ENV["TEST_API_KEY"]
+  config.verbose = true
+end
+
 module Test
   def client
-    @@client ||= Orchestrate::API::Wrapper.new File.join(File.dirname(__FILE__), "lib", "orch_config-demo.json")
+    @@client ||= Orchestrate::API::Wrapper.new
   end
 end
 

--- a/test/tests/orchestrate/api/wrapper_test.rb
+++ b/test/tests/orchestrate/api/wrapper_test.rb
@@ -1,0 +1,22 @@
+require_relative "../../../test_helper"
+
+describe Orchestrate::API::Wrapper do
+
+  before do
+    @client = Orchestrate::API::Wrapper.new
+  end
+
+  it "should initialize" do
+    client = Orchestrate::API::Wrapper.new
+    client.must_be_kind_of Orchestrate::API::Wrapper
+  end
+
+  it "should initialize with config" do
+    config = Orchestrate::Configuration.new \
+      api_key: "test-api-key"
+    client = Orchestrate::API::Wrapper.new(config)
+    client.must_be_kind_of Orchestrate::API::Wrapper
+    client.config.must_equal config
+  end
+
+end

--- a/test/tests/orchestrate/configuration_test.rb
+++ b/test/tests/orchestrate/configuration_test.rb
@@ -1,0 +1,64 @@
+require_relative "../../test_helper"
+
+describe Orchestrate::Configuration do
+
+  before do
+    @config = Orchestrate::Configuration.new
+  end
+
+  it "should initialize" do
+    config = Orchestrate::Configuration.new
+    config.must_be_kind_of Orchestrate::Configuration
+  end
+
+  it "should initialize with arguments" do
+    config = Orchestrate::Configuration.new \
+      api_key: "test-key",
+      base_url: "test-url",
+      verbose: true
+    config.must_be_kind_of Orchestrate::Configuration
+    config.api_key.must_equal "test-key"
+    config.base_url.must_equal "test-url"
+    config.verbose.must_equal true
+  end
+
+  describe "#api_key" do
+
+    it "should not have a default value" do
+      @config.api_key.must_be_nil
+    end
+
+    it "should be settable and gettable" do
+      @config.api_key = "test-key"
+      @config.api_key.must_equal "test-key"
+    end
+
+  end
+
+  describe "#base_url" do
+
+    it "should default to 'https://api.orchestrate.io/v0'" do
+      @config.base_url.must_equal "https://api.orchestrate.io/v0"
+    end
+
+    it "should be settable and gettable" do
+      @config.base_url = "test-url"
+      @config.base_url.must_equal "test-url"
+    end
+
+  end
+
+  describe "#verbose" do
+
+    it "should default to false" do
+      @config.verbose.must_equal false
+    end
+
+    it "should be settable and gettable" do
+      @config.verbose = true
+      @config.verbose.must_equal true
+    end
+
+  end
+
+end


### PR DESCRIPTION
Introduced a `Orchestrate::Configuration` object for configuring the library. Instead of providing a JSON file to Wrapper you can configure the library as such:

``` ruby
Orchestrate.configure do |config|
  config.api_key = ...
end
```

Or for a specific client, you can pass a configuration object to it that will override `Orchestrate.config`:

``` ruby
config = Orchestrate::Configuration.new(api_key: "foo")
client = Orchestrate::API::Wrapper.new(config)
```

Testing with a specific key can now be performed by running `TEST_API_KEY=the-key bundle exec rake test`.
